### PR TITLE
Version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ PHP versions:
 
 - 8.1.33 (only Azure container)
 - 8.2.29
-- 8.3.26
-- 8.4.13
-- 8.5.0 Beta 3 (only FPM-DEV)
+- 8.3.27
+- 8.4.14
+- 8.5.0 RC2 (only FPM-DEV, no Xdebug)
 
 Azure containers contain an SSH server and default Azure credentials.
 Johan van der Heide, Jield BV (johan.vanderheide@jield.nl)

--- a/php85-fpm-dev/Dockerfile
+++ b/php85-fpm-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.0beta3-fpm
+FROM php:8.5.0RC2-fpm
 
 LABEL maintainer="Johan van der Heide <info@jield.nl>"
 LABEL org.opencontainers.image.source="https://github.com/jield-webdev/docker-repos"
@@ -14,4 +14,13 @@ RUN echo 'date.timezone=Europe/Amsterdam' >> /usr/local/etc/php/conf.d/docker-ph
 # Set working directory
 WORKDIR /var/www
 
-RUN install-php-extensions gd redis xsl apcu igbinary intl gmp gettext zip opcache soap bcmath snappy pdo_mysql
+RUN #install-php-extensions gd redis xsl apcu igbinary intl gmp gettext zip opcache soap bcmath snappy pdo_mysql xdebug
+RUN install-php-extensions gd redis-6.3.0RC1 xsl apcu intl gmp gettext zip opcache soap bcmath snappy pdo_mysql #xdebug-^3.5
+
+## Install Xdebug 3.5.0alpha2 via PECL (without install-php-extensions)
+#RUN apt-get update \
+#    && apt-get install -y --no-install-recommends $PHPIZE_DEPS \
+#    && pecl install xdebug-3.5.0alpha2 \
+#    && docker-php-ext-enable xdebug \
+#    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $PHPIZE_DEPS \
+#    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request updates the PHP 8.5 FPM development container to use the latest release candidate and makes adjustments to the installed extensions, including changes related to Xdebug and Redis. The most important changes are grouped below:

**PHP Version Updates:**

* Updated the base image in `php85-fpm-dev/Dockerfile` from `php:8.5.0beta3-fpm` to `php:8.5.0RC2-fpm`, and updated the README to reflect this change. [[1]](diffhunk://#diff-85c2bc19baf262b64bf46f7366922429f4ea36a89991415c8e10232db6584844L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R29)
* Updated the listed PHP versions in the README: changed 8.3.26 to 8.3.27, 8.4.13 to 8.4.14, and clarified that 8.5.0 RC2 is used for FPM-DEV without Xdebug.

**Extension Installation Adjustments:**

* Modified the installation of PHP extensions in `php85-fpm-dev/Dockerfile`: switched Redis to version 6.3.0RC1, commented out Xdebug installation, and added notes for manual Xdebug installation via PECL.

**Xdebug Handling:**

* Documented and commented out steps for installing Xdebug 3.5.0alpha2 via PECL, indicating that Xdebug is not included by default in the FPM-DEV RC2 container.